### PR TITLE
CI: update GitHub Actions and add zizmor workflow scan

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,18 +9,21 @@ on:
   pull_request:
     branches: [ master, develop ]
 
+permissions: {}
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v5
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,11 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required for setup-java Maven cache (restore/save); omitted token defaults no longer include this.
+      actions: write
 
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK 11
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v5.2.0
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,9 +20,11 @@ jobs:
       actions: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Set up JDK 11
-      uses: actions/setup-java@v5.2.0
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,31 @@
+# Static analysis for GitHub Actions workflow security and configuration issues.
+# See https://docs.zizmor.sh/
+
+name: zizmor
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@v0.5.2
+        with:
+          # Console + annotations work without GitHub Advanced Security; enable SARIF upload instead if the repo has code scanning.
+          advanced-security: false
+          annotations: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,12 +19,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@v0.5.2
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:
           # Console + annotations work without GitHub Advanced Security; enable SARIF upload instead if the repo has code scanning.
           advanced-security: false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Modernize the Maven CI workflow** by upgrading `actions/checkout` and `actions/setup-java` so runners use a supported Node runtime and Maven caching uses a cache client compatible with GitHub’s API (fixes **"Cache service responded with 400"** with old `setup-java`; see [actions/setup-java#902](https://github.com/actions/setup-java/issues/902)).
- **Pin actions to immutable release SHAs** (`actions/checkout` v6.0.2, `actions/setup-java` v5.2.0, `zizmorcore/zizmor-action` v0.5.2) with version comments.
- **Least privilege:** Maven job checkout uses `persist-credentials: false` (zizmor job already had it). Job permissions: `contents: read`, **`actions: write`** for Maven cache with restricted top-level `permissions`.
- **Temurin** JDK 11; **zizmor** with `advanced-security: false` and `annotations: true`.

## Testing

- YAML validated locally; CI validates the full Maven build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8f40949-502b-4e32-b11c-f00332b7e68c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8f40949-502b-4e32-b11c-f00332b7e68c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded CI workflow components, tightened workflow permissions, and switched the JDK distribution while preserving Java 11 and Maven caching.
  * Added a CI static-analysis workflow that runs on pushes and pull requests to surface workflow configuration/security issues with annotated output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->